### PR TITLE
don't leak channel

### DIFF
--- a/signals.go
+++ b/signals.go
@@ -45,6 +45,8 @@ type Handler func() bool
 func Handle(signal os.Signal, handler Handler) {
 	channel := make(chan os.Signal, 1)
 	ossignal.Notify(channel, signal)
+	defer ossignal.Stop(c)
+
 	for {
 		<-channel
 		if handler() == false {


### PR DESCRIPTION
This pull requests fixes the leaky channel in `Handle` by deferring a `signal.Stop` call.
